### PR TITLE
Add support for Python 3.7 and 3.8a2, drop support for Python 3.4.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,15 @@
 language: python
+dist: xenial
 python:
   - 2.7
-  - 3.4
   - 3.5
   - 3.6
-  - pypy-5.6.0
+  - 3.7
+  - 3.8-dev
+  - pypy2.7-6.0
 matrix:
   include:
-    - python: 3.6
+    - python: 3.7
       name: "Flake8"
       install:  pip install -U flake8
       script: flake8 --doctests src setup.py

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,8 +2,12 @@
  Release History
 =================
 
-2.0.1 (unreleased)
-==================
+3.0 (unreleased)
+================
+
+- Drop support for Python 3.4.
+
+- Add support for Python 3.7 and 3.8a2.
 
 - Flake8 the code.
 

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ name = "zc.recipe.cmmi"
 
 setup(
     name=name,
-    version='2.0.1.dev0',
+    version='3.0.dev0',
     author="Jim Fulton",
     author_email="jim@zope.com",
     description="ZC Buildout recipe for configure/make/make install",
@@ -44,6 +44,8 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Natural Language :: English',
@@ -72,6 +74,7 @@ setup(
     packages=find_packages('src'),
     include_package_data=True,
     namespace_packages=['zc', 'zc.recipe'],
+    python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*',
     install_requires=[
         'zc.buildout >= 2.9.4',
         'setuptools'],

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8,py27,py34,py35,py36,pypy
+envlist = flake8,py27,py35,py36,py37,py38,pypy
 
 [testenv]
 commands =


### PR DESCRIPTION
Python 3.4 no longer works because zope.testrunner 5.0 does no longer support Python 3.4.